### PR TITLE
Add package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "git-sha-webpack-plugin",
+  "version": "0.0.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async": {
+      "version": "0.9.2",
+      "resolved": "https://npm.dev.s-cloud.net/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://npm.dev.s-cloud.net/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "git-bundle-sha": {
+      "version": "0.0.2",
+      "resolved": "https://npm.dev.s-cloud.net/git-bundle-sha/-/git-bundle-sha-0.0.2.tgz",
+      "integrity": "sha1-VAtmbyC1Lm3u38douQ1ojjKGJKs=",
+      "requires": {
+        "bluebird": "^2.3.0"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Security Update: Add package-lock.json
======================================

Following a [recent incident](https://blog.npmjs.org/post/175824896885/incident-report-npm-inc-operations-incident-of) we are attempting to update all projects using node to node 8 and ensure all libraries have a package-lock.json. Whilst this will only affect developers of the library itself, it does add some small mitigations for thesee types of incidents.

What you need to do now?
------------------------

As long as this is just a library, there's nothing really to test, just merge this PR and be thankful for the additional safety.
