### PR TITLE
Update to use node.js LTS (currently 14) & npm 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,36 @@
 {
   "name": "git-sha-webpack-plugin",
   "version": "0.0.6",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "0.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "async": "^0.9.0",
+        "git-bundle-sha": "^0.0.2"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+      "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+    },
+    "node_modules/bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "node_modules/git-bundle-sha": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/git-bundle-sha/-/git-bundle-sha-0.0.2.tgz",
+      "integrity": "sha1-VAtmbyC1Lm3u38douQ1ojjKGJKs=",
+      "dependencies": {
+        "bluebird": "^2.3.0"
+      }
+    }
+  },
   "dependencies": {
     "async": {
       "version": "0.9.2",


### PR DESCRIPTION
This updates to use node.js version 14, and npm 7. This uses the new npm 7
lockfile format.

This was a semi-automatically generated PR